### PR TITLE
Replace specificationForTasks array with a task array

### DIFF
--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -16,11 +16,6 @@ class Job {
         // length and arrivalTime have default value 0
     }
 
-    // other methods
-    public void addTask(int theMachine, int theTime) {
-        getTaskQ().put(new Task(theMachine, theTime));
-    }
-
     public void addTask(Task task) {
         getTaskQ().put(task);
     }

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -21,6 +21,10 @@ class Job {
         getTaskQ().put(new Task(theMachine, theTime));
     }
 
+    public void addTask(Task task) {
+        getTaskQ().put(task);
+    }
+
     /**
      * remove next task of job and return its time also update length
      */

--- a/src/applications/JobSpecification.java
+++ b/src/applications/JobSpecification.java
@@ -1,16 +1,7 @@
 package applications;
 
 public class JobSpecification {
-    private int numTasks;
     private Task[] tasks;
-
-    public void setNumTasks(int numTasks) {
-        this.numTasks = numTasks;
-    }
-
-    public int getNumTasks() {
-        return numTasks;
-    }
 
     public void setSpecificationsForTasks(Task[] specificationsForTasks) {
         this.tasks = specificationsForTasks;

--- a/src/applications/JobSpecification.java
+++ b/src/applications/JobSpecification.java
@@ -3,6 +3,7 @@ package applications;
 public class JobSpecification {
     private int numTasks;
     private int[] specificationsForTasks;
+    private Task[] tasks;
 
     public void setNumTasks(int numTasks) {
         this.numTasks = numTasks;
@@ -14,6 +15,10 @@ public class JobSpecification {
 
     public void setSpecificationsForTasks(int[] specificationsForTasks) {
         this.specificationsForTasks = specificationsForTasks;
+    }
+
+    public void setSpecificationsForTasks(Task[] specificationsForTasks) {
+        this.tasks = specificationsForTasks;
     }
 
     public int[] getSpecificationsForTasks() {

--- a/src/applications/JobSpecification.java
+++ b/src/applications/JobSpecification.java
@@ -2,7 +2,6 @@ package applications;
 
 public class JobSpecification {
     private int numTasks;
-    private int[] specificationsForTasks;
     private Task[] tasks;
 
     public void setNumTasks(int numTasks) {
@@ -13,16 +12,8 @@ public class JobSpecification {
         return numTasks;
     }
 
-    public void setSpecificationsForTasks(int[] specificationsForTasks) {
-        this.specificationsForTasks = specificationsForTasks;
-    }
-
     public void setSpecificationsForTasks(Task[] specificationsForTasks) {
         this.tasks = specificationsForTasks;
-    }
-
-    public int[] getSpecificationsForTasks() {
-        return specificationsForTasks;
     }
 
     public Task[] getTasks() {

--- a/src/applications/JobSpecification.java
+++ b/src/applications/JobSpecification.java
@@ -3,8 +3,8 @@ package applications;
 public class JobSpecification {
     private Task[] tasks;
 
-    public void setSpecificationsForTasks(Task[] specificationsForTasks) {
-        this.tasks = specificationsForTasks;
+    public void setTasks(Task[] tasks) {
+        this.tasks = tasks;
     }
 
     public Task[] getTasks() {

--- a/src/applications/JobSpecification.java
+++ b/src/applications/JobSpecification.java
@@ -24,4 +24,8 @@ public class JobSpecification {
     public int[] getSpecificationsForTasks() {
         return specificationsForTasks;
     }
+
+    public Task[] getTasks() {
+        return tasks;
+    }
 }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -72,17 +72,20 @@ public class MachineShopSimulator {
         // input the jobs
         Job theJob;
         for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobSpecifications(i).getNumTasks();
+            Task[] tasks = specification.getJobSpecifications(i).getTasks();
             int firstMachine = 0; // machine for first task
 
             // create the job
             theJob = new Job(i);
-            for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
-                if (j == 1)
-                    firstMachine = theMachine; // job's first machine
-                theJob.addTask(theMachine, theTaskTime); // add to
+
+            for (int j = 0; j < tasks.length; j++) {
+                Task task = tasks[j];
+                //int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
+                //int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
+                if (j == 0)
+                    firstMachine = task.getMachine(); //theMachine; // job's first machine
+                //theJob.addTask(theMachine, theTaskTime); // add to
+                theJob.addTask(task);
             } // task queue
             machine[firstMachine].getJobQ().put(theJob);
         }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -80,11 +80,8 @@ public class MachineShopSimulator {
 
             for (int j = 0; j < tasks.length; j++) {
                 Task task = tasks[j];
-                //int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                //int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
                 if (j == 0)
-                    firstMachine = task.getMachine(); //theMachine; // job's first machine
-                //theJob.addTask(theMachine, theTaskTime); // add to
+                    firstMachine = task.getMachine(); // job's first machine
                 theJob.addTask(task);
             } // task queue
             machine[firstMachine].getJobQ().put(theJob);

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -32,10 +32,6 @@ public class SimulationSpecification {
         return changeOverTimes[machineNumber];
     }
 
-    public void setSpecificationsForTasks(int jobNumber, int[] specificationsForTasks) {
-        jobSpecifications[jobNumber].setSpecificationsForTasks(specificationsForTasks);
-    }
-
     public void setSpecificationsForTasks(int jobNumber, Task[] tasks) {
         jobSpecifications[jobNumber].setSpecificationsForTasks(tasks);
     }

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -33,7 +33,7 @@ public class SimulationSpecification {
     }
 
     public void setSpecificationsForTasks(int jobNumber, Task[] tasks) {
-        jobSpecifications[jobNumber].setSpecificationsForTasks(tasks);
+        jobSpecifications[jobNumber].setTasks(tasks);
     }
 
     public void setJobSpecification(JobSpecification[] jobSpecifications) {

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -56,7 +56,7 @@ public class SimulationSpecification {
         builder.append("change overs: ").append(Arrays.toString(changeOverTimes));
         for (int i=1; i<=numJobs; ++i) {
             builder.append("; job ").append(i).append(" tasks: ");
-            builder.append(Arrays.toString(jobSpecifications[i].getSpecificationsForTasks()));
+            builder.append(Arrays.toString(jobSpecifications[i].getTasks()));
         }
 
         builder.append(">");

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -36,6 +36,10 @@ public class SimulationSpecification {
         jobSpecifications[jobNumber].setSpecificationsForTasks(specificationsForTasks);
     }
 
+    public void setSpecificationsForTasks(int jobNumber, Task[] tasks) {
+        jobSpecifications[jobNumber].setSpecificationsForTasks(tasks);
+    }
+
     public void setJobSpecification(JobSpecification[] jobSpecifications) {
         this.jobSpecifications = jobSpecifications;
     }

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -58,6 +58,7 @@ public class SpecificationReader {
                 specificationsForTasks[2*(j-1)+2] = theTaskTime;
             }
             specification.setSpecificationsForTasks(i, specificationsForTasks);
+            specification.setSpecificationsForTasks(i, taskArray);
         }
     }
 

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -40,7 +40,6 @@ public class SpecificationReader {
             int tasks = keyboard.readInteger(); // number of tasks
             if (tasks < 1)
                 throw new MyInputException(MachineShopSimulator.EACH_JOB_MUST_HAVE_AT_LEAST_1_TASK);
-            jobSpecifications[i].setNumTasks(tasks);
 
             Task[] taskArray = new Task[tasks];
 

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -43,6 +43,7 @@ public class SpecificationReader {
             jobSpecifications[i].setNumTasks(tasks);
 
             int[] specificationsForTasks = new int[2 * tasks + 1];
+            Task[] taskArray = new Task[tasks];
 
             System.out.println("Enter the tasks (machine, time)"
                     + " in process order");
@@ -52,6 +53,7 @@ public class SpecificationReader {
                 if (theMachine < 1 || theMachine > specification.getNumMachines()
                         || theTaskTime < 1)
                     throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
+                taskArray[j-1] = new Task(theMachine, theTaskTime);
                 specificationsForTasks[2*(j-1)+1] = theMachine;
                 specificationsForTasks[2*(j-1)+2] = theTaskTime;
             }

--- a/src/applications/SpecificationReader.java
+++ b/src/applications/SpecificationReader.java
@@ -42,22 +42,18 @@ public class SpecificationReader {
                 throw new MyInputException(MachineShopSimulator.EACH_JOB_MUST_HAVE_AT_LEAST_1_TASK);
             jobSpecifications[i].setNumTasks(tasks);
 
-            int[] specificationsForTasks = new int[2 * tasks + 1];
             Task[] taskArray = new Task[tasks];
 
             System.out.println("Enter the tasks (machine, time)"
                     + " in process order");
-            for (int j = 1; j <= tasks; j++) { // get tasks for job i
+            for (int j = 0; j < tasks; j++) { // get tasks for job i
                 int theMachine = keyboard.readInteger();
                 int theTaskTime = keyboard.readInteger();
                 if (theMachine < 1 || theMachine > specification.getNumMachines()
                         || theTaskTime < 1)
                     throw new MyInputException(MachineShopSimulator.BAD_MACHINE_NUMBER_OR_TASK_TIME);
-                taskArray[j-1] = new Task(theMachine, theTaskTime);
-                specificationsForTasks[2*(j-1)+1] = theMachine;
-                specificationsForTasks[2*(j-1)+2] = theTaskTime;
+                taskArray[j] = new Task(theMachine, theTaskTime);
             }
-            specification.setSpecificationsForTasks(i, specificationsForTasks);
             specification.setSpecificationsForTasks(i, taskArray);
         }
     }

--- a/src/applications/Task.java
+++ b/src/applications/Task.java
@@ -19,4 +19,12 @@ class Task {
     public int getTime() {
         return time;
     }
+
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{ Machine Number: ").append(machine).append(" | Duration: ").append(time).append(" }");
+        return builder.toString();
+    }
 }

--- a/tests/properties/applications/SimulationProperties.java
+++ b/tests/properties/applications/SimulationProperties.java
@@ -3,6 +3,8 @@ package applications;
 import com.pholser.junit.quickcheck.From;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 import static junit.framework.TestCase.assertEquals;
@@ -10,7 +12,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-@RunWith(JUnitQuickcheck.class)
+// @RunWith(JUnitQuickcheck.class)
+@Ignore
 public class SimulationProperties {
     @Property
     public void lastJobCompletesAtOverallFinishTime(

--- a/tests/properties/applications/SimulationProperties.java
+++ b/tests/properties/applications/SimulationProperties.java
@@ -12,8 +12,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-// @RunWith(JUnitQuickcheck.class)
-@Ignore
+@RunWith(JUnitQuickcheck.class)
+//@Ignore
 public class SimulationProperties {
     @Property
     public void lastJobCompletesAtOverallFinishTime(
@@ -81,10 +81,9 @@ public class SimulationProperties {
 
         for (int i=1; i<=numJobs; ++i) {
             JobSpecification jobSpecification = specification.getJobSpecifications(i);
-            int numTasks = jobSpecification.getNumTasks();
-            int[] specsForTasks = jobSpecification.getSpecificationsForTasks();
-            for (int j=1; j<=numTasks; ++j) {
-                int theMachine = specsForTasks[2*(j-1)+1];
+	    Task[] tasks = jobSpecification.getTasks();
+            for (int j=0; j<tasks.length; ++j) {
+                int theMachine = tasks[j].getMachine();
                 ++expectedMachineTaskCounts[theMachine];
             }
         }

--- a/tests/properties/applications/SimulationProperties.java
+++ b/tests/properties/applications/SimulationProperties.java
@@ -81,7 +81,7 @@ public class SimulationProperties {
 
         for (int i=1; i<=numJobs; ++i) {
             JobSpecification jobSpecification = specification.getJobSpecifications(i);
-	    Task[] tasks = jobSpecification.getTasks();
+	        Task[] tasks = jobSpecification.getTasks();
             for (int j=0; j<tasks.length; ++j) {
                 int theMachine = tasks[j].getMachine();
                 ++expectedMachineTaskCounts[theMachine];

--- a/tests/properties/applications/SimulationSpecificationGenerator.java
+++ b/tests/properties/applications/SimulationSpecificationGenerator.java
@@ -51,17 +51,13 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
         result.setJobSpecification(jobSpecifications);
         for (int i=1; i<=numJobs; ++i) {
             int numTasks = r.nextInt(MAX_TASKS) + 1;
-            jobSpecifications[i].setNumTasks(numTasks);
 
-            //int[] specificationsForTasks = new int[2 * numTasks + 1];
             Task[] specificationsForTasks = new Task[numTasks];
 
             for (int j = 0; j < numTasks; ++j) {
                 int theMachine = r.nextInt(numMachines) + 1;
                 int theTaskTime = r.nextInt(MAX_TASK_TIME) + 1;
                 specificationsForTasks[j] = new Task(theMachine, theTaskTime);
-                // specificationsForTasks[2 * (j - 1) + 1] = theMachine;
-                // specificationsForTasks[2 * (j - 1) + 2] = theTaskTime;
             }
             result.setSpecificationsForTasks(i, specificationsForTasks);
         }
@@ -146,7 +142,6 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
                 }
             }
             JobSpecification newJobSpec = new JobSpecification();
-            newJobSpec.setNumTasks(newNumTasks);
             newJobSpec.setSpecificationsForTasks(newTasks);
             newJobSpecs[i] = newJobSpec;
         }
@@ -190,7 +185,7 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
         int size = simulationSpecification.getNumMachines();
         size += simulationSpecification.getNumJobs();
         for (int i=1; i<=simulationSpecification.getNumJobs(); ++i) {
-            size += simulationSpecification.getJobSpecifications(i).getNumTasks();
+            size += simulationSpecification.getJobSpecifications(i).getTasks().length;
         }
 
         return BigDecimal.valueOf(size);

--- a/tests/properties/applications/SimulationSpecificationGenerator.java
+++ b/tests/properties/applications/SimulationSpecificationGenerator.java
@@ -117,11 +117,11 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
         JobSpecification[] newJobSpecs = new JobSpecification[numJobs+1];
         for (int i=1; i<=numJobs; ++i) {
             JobSpecification jobSpec = spec.getJobSpecifications(i);
-            int numTasks = jobSpec.getNumTasks();
-            int[] specsForTasks = jobSpec.getSpecificationsForTasks();
+            Task[] specsForTasks = jobSpec.getTasks();
+            int numTasks = specsForTasks.length;
             int numTasksOnThisMachine = 0;
-            for (int j=1; j<=numTasks; ++j) {
-                if (specsForTasks[2*(j-1)+1] == machineToRemove) {
+            for (int j=0; j<specsForTasks.length; ++j) {
+                if (specsForTasks[j].getMachine() == machineToRemove) {
                     ++numTasksOnThisMachine;
                 }
             }
@@ -134,21 +134,20 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
             }
 
             final int newNumTasks = numTasks - numTasksOnThisMachine;
-            int[] newSpecsForTasks = new int[2* newNumTasks + 1];
-            for (int j=1, k=1; j<=numTasks; ++j) {
-                int machine = specsForTasks[2*(j-1)+1];
+            Task[] newTasks = new Task[newNumTasks];
+            for (int j=0, k=0; j<numTasks; ++j) {
+                int machine = specsForTasks[j].getMachine();
                 if (machine != machineToRemove) {
                     if (machine > machineToRemove) {
                         --machine;
                     }
-                    newSpecsForTasks[2*(k-1)+1] = machine;
-                    newSpecsForTasks[2*(k-1)+2] = specsForTasks[2*(j-1)+2];
+                    newTasks[k] = new Task(machine, specsForTasks[j].getTime());
                     ++k;
                 }
             }
             JobSpecification newJobSpec = new JobSpecification();
             newJobSpec.setNumTasks(newNumTasks);
-            newJobSpec.setSpecificationsForTasks(newSpecsForTasks);
+            newJobSpec.setSpecificationsForTasks(newTasks);
             newJobSpecs[i] = newJobSpec;
         }
         smallerSpec.setJobSpecification(newJobSpecs);

--- a/tests/properties/applications/SimulationSpecificationGenerator.java
+++ b/tests/properties/applications/SimulationSpecificationGenerator.java
@@ -53,13 +53,15 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
             int numTasks = r.nextInt(MAX_TASKS) + 1;
             jobSpecifications[i].setNumTasks(numTasks);
 
-            int[] specificationsForTasks = new int[2 * numTasks + 1];
+            //int[] specificationsForTasks = new int[2 * numTasks + 1];
+            Task[] specificationsForTasks = new Task[numTasks];
 
-            for (int j = 1; j <= numTasks; ++j) {
+            for (int j = 0; j < numTasks; ++j) {
                 int theMachine = r.nextInt(numMachines) + 1;
                 int theTaskTime = r.nextInt(MAX_TASK_TIME) + 1;
-                specificationsForTasks[2 * (j - 1) + 1] = theMachine;
-                specificationsForTasks[2 * (j - 1) + 2] = theTaskTime;
+                specificationsForTasks[j] = new Task(theMachine, theTaskTime);
+                // specificationsForTasks[2 * (j - 1) + 1] = theMachine;
+                // specificationsForTasks[2 * (j - 1) + 2] = theTaskTime;
             }
             result.setSpecificationsForTasks(i, specificationsForTasks);
         }

--- a/tests/properties/applications/SimulationSpecificationGenerator.java
+++ b/tests/properties/applications/SimulationSpecificationGenerator.java
@@ -142,7 +142,7 @@ public class SimulationSpecificationGenerator extends Generator<SimulationSpecif
                 }
             }
             JobSpecification newJobSpec = new JobSpecification();
-            newJobSpec.setSpecificationsForTasks(newTasks);
+            newJobSpec.setTasks(newTasks);
             newJobSpecs[i] = newJobSpec;
         }
         smallerSpec.setJobSpecification(newJobSpecs);

--- a/tests/unitTests/applications/MachineTest.java
+++ b/tests/unitTests/applications/MachineTest.java
@@ -16,7 +16,8 @@ public class MachineTest {
         for (int i = 0; i < 5; i++) {
             Job newJob = new Job(i);
             newJob.setArrivalTime(i+1);
-            newJob.addTask(1, 2);
+            Task newTask = new Task(1,2);
+            newJob.addTask(newTask);
             jobs.put(newJob);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description & Motivation
<!--- Describe your changes in detail and the motivation for why it was required. -->
<!--- What problem does it solve? -->
<!--- Describe the smell this addresses and the particular location the smell occurs -->
<!--- Provide a summary of the description in the issue, but don’t necessarily copy all the details over to the pull request. -->
<!--- Make sure to include enough information that people don’t have to click over the issue if they aren’t inclined. -->
<!--- You need to make sure the issue has the necessary detail. -->
We replaced the specificationForTasks array with a new Task array. The specificationForTasks was a single integer array that stored the machine number and the time for each task at every other index. This wasn't optimal, so we replaced it was a array of type Task. Now there is an actual distinction  in the code between different tasks. We also changed it to use the 0-th array and got rid of the numTask field as well as it's setter and getter since that only existed to keep track of the actual length of the specificationForTasks array.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- Please link to the issue here: -->
Fixes: #4 Data structure issue: specificationForTasks array

## Smell impact
<!--- What smells does this reduce/eliminate? -->
<!--- What smells does this introduce/increase? -->
<!--- Were there old smells that you hadn’t noticed that this helps bring to your attention? -->
The jobSpecification class now just contains a single field, a setter and getter for it. We should consider whether some related logic can be pulled in.

We noticed that the job specification array could also use some improvement. Currently, it starts storing values at index 1.

## Testing & Screenshots:
<!--- Screenshot of the code coverage report so we can track that over time. -->
<!--- Mention any new tests here as well. -->
Before:
![image](https://user-images.githubusercontent.com/46685572/93820743-34e99680-fc23-11ea-9719-1c8fe15e778a.png)
After:
![image](https://user-images.githubusercontent.com/46744598/94292079-171d7980-ff22-11ea-8cc7-5a3f5417c0cc.png)

There is a toString() function in SimulationSpecification that used getSpecificationForTasks function. Although it wasn't used anywhere, since the functionality existed, we decided to maintain it and wrote a toString() for Task so we could get a reasonable output for Task instead of just a pointer to a location in memory. That lowered the the coverage a bit, since Task has a new toString() function now that isn't called as well.

No new tests were written, but the property tests as well as unit test for Machine were updated to use task array.
- [x] All new and existing tests passed.
