### PR TITLE
Give generic type to LinkedQueue

### DIFF
--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -25,7 +25,7 @@ class Job {
      * remove next task of job and return its time also update length
      */
     public int removeNextTask() {
-        int theTime = ((Task) getTaskQ().remove()).getTime();
+        int theTime = getTaskQ().remove().getTime();
         length = getLength() + theTime;
         return theTime;
     }

--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -4,7 +4,7 @@ import dataStructures.LinkedQueue;
 
 class Job {
     // data members
-    private LinkedQueue taskQ; // this job's tasks
+    private LinkedQueue<Task> taskQ; // this job's tasks
     private int length; // sum of scheduled task times
     private int arrivalTime; // arrival time at current queue
     private int id; // job identifier
@@ -12,7 +12,7 @@ class Job {
     // constructor
     Job(int theId) {
         id = theId;
-        taskQ = new LinkedQueue();
+        taskQ = new LinkedQueue<Task>();
         // length and arrivalTime have default value 0
     }
 
@@ -30,7 +30,7 @@ class Job {
         return theTime;
     }
 
-    public LinkedQueue getTaskQ() {
+    public LinkedQueue<Task> getTaskQ() {
         return taskQ;
     }
 

--- a/src/applications/Machine.java
+++ b/src/applications/Machine.java
@@ -4,7 +4,7 @@ import dataStructures.LinkedQueue;
 
 class Machine {
     // data members
-    private LinkedQueue jobQ; // queue of waiting jobs for this machine
+    private LinkedQueue<Job> jobQ; // queue of waiting jobs for this machine
     private int changeTime; // machine change-over time
     private int totalWait; // total delay at this machine
     private int numTasks; // number of tasks processed on this machine
@@ -12,10 +12,10 @@ class Machine {
 
     // constructor
     Machine() {
-        jobQ = new LinkedQueue();
+        jobQ = new LinkedQueue<Job>();
     }
 
-    public LinkedQueue getJobQ() {
+    public LinkedQueue<Job> getJobQ() {
         return jobQ;
     }
 

--- a/src/applications/Machine.java
+++ b/src/applications/Machine.java
@@ -48,7 +48,7 @@ class Machine {
     }
 
     public void updateActiveJob() {
-        activeJob = (Job) jobQ.remove();
+        activeJob = jobQ.remove();
     }
 
 	public void setInactive() {

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -30,7 +30,7 @@ public class MachineShopSimulator {
             return false;
         } else {// theJob has a next task
                 // get machine for next task
-            int p = ((Task) theJob.getTaskQ().getFrontElement()).getMachine();
+            int p = theJob.getTaskQ().getFrontElement().getMachine();
             // put on machine p's wait queue
             machine[p].getJobQ().put(theJob);
             theJob.setArrivalTime(timeNow);

--- a/src/dataStructures/ChainNode.java
+++ b/src/dataStructures/ChainNode.java
@@ -4,20 +4,20 @@
 
 package dataStructures;
 
-class ChainNode {
+class ChainNode<Type> {
     // package visible data members
-    Object element;
-    ChainNode next;
+    Type element;
+    ChainNode<Type> next;
 
     // package visible constructors
     ChainNode() {
     }
 
-    ChainNode(Object element) {
+    ChainNode(Type element) {
         this.element = element;
     }
 
-    ChainNode(Object element, ChainNode next) {
+    ChainNode(Type element, ChainNode<Type> next) {
         this.element = element;
         this.next = next;
     }

--- a/src/dataStructures/LinkedQueue.java
+++ b/src/dataStructures/LinkedQueue.java
@@ -2,10 +2,10 @@
 
 package dataStructures;
 
-public class LinkedQueue<Type> implements Queue {
+public class LinkedQueue<Type> implements Queue<Type> {
     // data members
-    protected ChainNode front;
-    protected ChainNode rear;
+    protected ChainNode<Type> front;
+    protected ChainNode<Type> rear;
 
     // constructors
     /** create an empty queue */
@@ -27,7 +27,7 @@ public class LinkedQueue<Type> implements Queue {
      * @return the element at the front of the queue
      * @return null if the queue is empty
      */
-    public Object getFrontElement() {
+    public Type getFrontElement() {
         if (isEmpty())
             return null;
         else
@@ -38,7 +38,7 @@ public class LinkedQueue<Type> implements Queue {
      * @return the element at the rear of the queue
      * @return null if the queue is empty
      */
-    public Object getRearElement() {
+    public Type getRearElement() {
         if (isEmpty())
             return null;
         else
@@ -46,9 +46,9 @@ public class LinkedQueue<Type> implements Queue {
     }
 
     /** insert theElement at the rear of the queue */
-    public void put(Object theElement) {
+    public void put(Type theElement) {
         // create a node for theElement
-        ChainNode p = new ChainNode(theElement, null);
+        ChainNode<Type> p = new ChainNode<Type>(theElement, null);
 
         // append p to the chain
         if (front == null)
@@ -64,10 +64,10 @@ public class LinkedQueue<Type> implements Queue {
      * @return removed element
      * @return null if the queue is empty
      */
-    public Object remove() {
+    public Type remove() {
         if (isEmpty())
             return null;
-        Object frontElement = front.element;
+        Type frontElement = front.element;
         front = front.next;
         if (isEmpty())
             rear = null; // enable garbage collection
@@ -77,7 +77,7 @@ public class LinkedQueue<Type> implements Queue {
     public int size() {
         int result = 0;
 
-        ChainNode currentNode = front;
+        ChainNode<Type> currentNode = front;
         while (currentNode != null) {
             ++result;
             currentNode = currentNode.next;
@@ -105,7 +105,7 @@ public class LinkedQueue<Type> implements Queue {
 
     @Override public String toString() {
         String result = "<";
-        ChainNode node = front;
+        ChainNode<Type> node = front;
         while (node != null) {
             result += node.element.toString() + ", ";
             node = node.next;

--- a/src/dataStructures/LinkedQueue.java
+++ b/src/dataStructures/LinkedQueue.java
@@ -2,7 +2,7 @@
 
 package dataStructures;
 
-public class LinkedQueue implements Queue {
+public class LinkedQueue<Type> implements Queue {
     // data members
     protected ChainNode front;
     protected ChainNode rear;
@@ -60,7 +60,7 @@ public class LinkedQueue implements Queue {
 
     /**
      * remove an element from the front of the queue
-     * 
+     *
      * @return removed element
      * @return null if the queue is empty
      */
@@ -88,12 +88,12 @@ public class LinkedQueue implements Queue {
 
     /** test program */
     public static void main(String[] args) {
-        LinkedQueue q = new LinkedQueue(3);
+        LinkedQueue<Integer> q = new LinkedQueue<Integer>(3);
         // add a few elements
-        q.put(new Integer(1));
-        q.put(new Integer(2));
-        q.put(new Integer(3));
-        q.put(new Integer(4));
+        q.put(1);
+        q.put(2);
+        q.put(3);
+        q.put(4);
 
         // delete all elements
         while (!q.isEmpty()) {

--- a/src/dataStructures/Queue.java
+++ b/src/dataStructures/Queue.java
@@ -1,13 +1,13 @@
 package dataStructures;
 
-public interface Queue {
+public interface Queue<Type> {
     public boolean isEmpty();
 
-    public Object getFrontElement();
+    public Type getFrontElement();
 
-    public Object getRearElement();
+    public Type getRearElement();
 
-    public void put(Object theObject);
+    public void put(Type theObject);
 
-    public Object remove();
+    public Type remove();
 }

--- a/tests/acceptanceTests/dataStructures/LinkedQueueAcceptanceTest.java
+++ b/tests/acceptanceTests/dataStructures/LinkedQueueAcceptanceTest.java
@@ -18,19 +18,18 @@ public class LinkedQueueAcceptanceTest {
         q.put(Integer.valueOf(3));
         q.put(Integer.valueOf(4));
 
-        assertEquals(4, q.getRearElement());
-        assertEquals(1, q.getFrontElement());
-        assertEquals(1, q.remove());
-        assertEquals(4, q.getRearElement());
-        assertEquals(2, q.getFrontElement());
-        assertEquals(2, q.remove());
-        assertEquals(4, q.getRearElement());
-        assertEquals(3, q.getFrontElement());
-        assertEquals(3, q.remove());
-        assertEquals(4, q.getRearElement());
-        assertEquals(4, q.getFrontElement());
-        assertEquals(4, q.remove());
-
+        assertTrue(4 == q.getRearElement());
+        assertTrue(1 == q.getFrontElement());
+        assertTrue(1 == q.remove());
+        assertTrue(4 == q.getRearElement());
+        assertTrue(2 == q.getFrontElement());
+        assertTrue(2 == q.remove());
+        assertTrue(4 == q.getRearElement());
+        assertTrue(3 == q.getFrontElement());
+        assertTrue(3 == q.remove());
+        assertTrue(4 == q.getRearElement());
+        assertTrue(4 == q.getFrontElement());
+        assertTrue(4 == q.remove());
         assertTrue(q.isEmpty());
     }
 

--- a/tests/acceptanceTests/dataStructures/LinkedQueueAcceptanceTest.java
+++ b/tests/acceptanceTests/dataStructures/LinkedQueueAcceptanceTest.java
@@ -4,14 +4,14 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class LinkedQueueAcceptanceTest {
-    
+
     /**
      * A simple acceptance test based on the one little test that
      * Sahni provided with the code.
      */
     @Test
     public void sahniTest() {
-        LinkedQueue q = new LinkedQueue(3);
+        LinkedQueue<Integer> q = new LinkedQueue<Integer>(3);
         // add a few elements
         q.put(Integer.valueOf(1));
         q.put(Integer.valueOf(2));
@@ -30,13 +30,13 @@ public class LinkedQueueAcceptanceTest {
         assertEquals(4, q.getRearElement());
         assertEquals(4, q.getFrontElement());
         assertEquals(4, q.remove());
-        
+
         assertTrue(q.isEmpty());
     }
-    
+
     @Test
     public void emptyQueueTests() {
-        LinkedQueue q = new LinkedQueue();
+        LinkedQueue<Object> q = new LinkedQueue<Object>();
         assertTrue(q.isEmpty());
         assertNull(q.getFrontElement());
         assertNull(q.getRearElement());

--- a/tests/properties/dataStructures/LinkedQueueProperties.java
+++ b/tests/properties/dataStructures/LinkedQueueProperties.java
@@ -15,7 +15,7 @@ import static org.junit.Assume.assumeThat;
 public class LinkedQueueProperties {
 
     @Property
-    public void removingDecreasesSizeByOne(@From(QueueGenerator.class) LinkedQueue queue) {
+    public void removingDecreasesSizeByOne(@From(QueueGenerator.class) LinkedQueue<Integer> queue) {
         assumeThat(queue.isEmpty(), not(true));
         final int originalSize = queue.size();
         queue.remove();
@@ -24,7 +24,7 @@ public class LinkedQueueProperties {
     }
 
     @Property
-    public void addingIncreasesSizeByOne(@From(QueueGenerator.class) LinkedQueue queue) {
+    public void addingIncreasesSizeByOne(@From(QueueGenerator.class) LinkedQueue<Integer> queue) {
         final int newValue = 5896320;
         final int originalSize = queue.size();
         queue.put(newValue);
@@ -33,7 +33,7 @@ public class LinkedQueueProperties {
     }
 
     @Property
-    public void allElementsAreInts(@From(QueueGenerator.class) LinkedQueue queue) {
+    public void allElementsAreInts(@From(QueueGenerator.class) LinkedQueue<Integer> queue) {
         while (!queue.isEmpty()) {
             Object value = queue.remove();
             assertEquals(value.getClass(), Integer.class);
@@ -41,7 +41,7 @@ public class LinkedQueueProperties {
     }
 
     @Property
-    public void canRemoveNumElementsEqualToSize(@From(QueueGenerator.class) LinkedQueue queue) {
+    public void canRemoveNumElementsEqualToSize(@From(QueueGenerator.class) LinkedQueue<Integer> queue) {
         final int size = queue.size();
         for (int i=0; i<size; ++i) {
             assertNotNull(queue.remove());

--- a/tests/unitTests/applications/MachineTest.java
+++ b/tests/unitTests/applications/MachineTest.java
@@ -53,7 +53,7 @@ public class MachineTest {
     @Test
     public final void worksNextTaskCorrectly() {
         int timeNow =  20;
-        Job frontElement = (Job) machine.getJobQ().getFrontElement();
+        Job frontElement = machine.getJobQ().getFrontElement();
         int arrivalTime = frontElement.getArrivalTime();
 
         assertEquals(0, machine.getTotalWait());

--- a/tests/unitTests/applications/MachineTest.java
+++ b/tests/unitTests/applications/MachineTest.java
@@ -12,7 +12,7 @@ public class MachineTest {
 
     @Before public void initialize() {
         machine = new Machine();
-        LinkedQueue jobs = machine.getJobQ();
+        LinkedQueue<Job> jobs = machine.getJobQ();
         for (int i = 0; i < 5; i++) {
             Job newJob = new Job(i);
             newJob.setArrivalTime(i+1);

--- a/tests/unitTests/dataStructures/LinkedQueueTest.java
+++ b/tests/unitTests/dataStructures/LinkedQueueTest.java
@@ -8,7 +8,7 @@ public class LinkedQueueTest {
 
     @Test
     public void testIsEmpty() {
-        LinkedQueue queue = new LinkedQueue();
+        LinkedQueue<String> queue = new LinkedQueue<String>();
         assertTrue(queue.isEmpty());
         queue.put("An item");
         assertFalse(queue.isEmpty());
@@ -18,7 +18,7 @@ public class LinkedQueueTest {
 
     @Test
     public void testQueueOperations() {
-        LinkedQueue queue = new LinkedQueue();
+        LinkedQueue<String> queue = new LinkedQueue<String>();
         assertNull(queue.getFrontElement());
         assertNull(queue.getRearElement());
         final String firstItem = "First item";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description & Motivation
<!--- Describe your changes in detail and the motivation for why it was required. -->
<!--- What problem does it solve? -->
<!--- Describe the smell this addresses and the particular location the smell occurs -->
<!--- Provide a summary of the description in the issue, but don’t necessarily copy all the details over to the pull request. -->
<!--- Make sure to include enough information that people don’t have to click over the issue if they aren’t inclined. -->
The implementation of LinkedQueue data structure required objects removed from the Queue to be cast to a specific class ( Job, Task,  etc), so their respective functions could be called on that object. We thought this was a bit of inappropriate intimacy and a LinkedQueue should just know what type of data it should store. Furthermore, it will also prevent storing different types of objects in the same queue. 

We gave LinkedQueue class a generic Type and also changed it's funcrions to return an object of that type specifically. This required also giving the building blocks of the LinkedQueue, ChainNode and Queue, generic types .

We specified specific types to LinkedQueue uses throughout the code. We also changed LinkedQueueAcceptanceTest to use assertTrue since, assertTrue unpacks the wrapper around an object when checking equality whereas assertEquals expects two arguments to be the same Type.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- Please link to the issue here: -->
Fix: #11 Data structure Issue: LinkedQueue causes Inappropriate Intimacy

## Smell impact
<!--- What smells does this reduce/eliminate? -->
<!--- What smells does this introduce/increase? -->
<!--- Were there old smells that you hadn’t noticed that this helps bring to your attention? -->
 Objects don't need to be cast and encapsulated just to call their respective functions. The semantic distance between a queue variable name and what it actually holds has been reduced. The name actually represent the data type of what the queue holds rather than storing Objects.

The lines of code added and deleted are the same, because the the main change is replacing Object to a Generic Type. Only four lines of code contained casting when removing item from a LinkedQueue, which might be seem like too minor of a benefit at the current time, but it could be helpful in the future and the relative time spent for these changes was only around 1.5 hours.

We didn't noticed any new smells.

## Testing & Screenshots:
<!--- Screenshot of the code coverage report so we can track that over time. -->
<!--- Mention any new tests here as well. -->
Before:
![image](https://user-images.githubusercontent.com/46685572/95148258-82e4bb00-0748-11eb-8605-983de278a5d4.png)
After:
![image](https://user-images.githubusercontent.com/46685572/95138586-32616380-0730-11eb-88b9-abb3793c175b.png)

- [x] All new and existing tests passed.
